### PR TITLE
Add /assets to .npmignore to reduce the npm package size by 38.7 MiB

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@
 /samples
 
 /secrets.md
+/assets


### PR DESCRIPTION
Hi! Thanks for maintaining this package. We realized that just installing this `spacetrim` package will increase the size of `node_modules` by 38.5 MiB due to image files in `assets/ai/wallpaper/gallery`.

This PR removes that images by adding `/assets` to `.npmignore`.

Right now, `spacetrim` is the heaviest thing in `node_modules` when installing `webdriverio@8.36.1` (current latest version) so it would be really nice if we can just remove these images.

The following shows total file sizes for each directory inside `node_modules` just after running `npm install webdriverio@8.36.1`:

<img width="517" alt="Screenshot 2024-04-23 at 2 21 09" src="https://github.com/hejny/spacetrim/assets/2931577/ca0a3e14-239e-438d-a04c-c29bee1bc22b">
